### PR TITLE
refactor(stats): migrate to use RPC for monthly overview

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -5,6 +5,7 @@ import 'package:moneyplus/presentation/transactions/cubit/transaction_cubit.dart
 import '../../data/repository/account_repository.dart';
 import '../../data/repository/authentication_repository.dart';
 import '../../data/repository/fake_statistics_repository.dart';
+import '../../data/repository/statistics_repository_impl.dart';
 import '../../data/repository/transaction_repository_stub.dart';
 import '../../data/repository/user_money_repository.dart';
 import '../../data/service/app_secrets_provider.dart';
@@ -27,7 +28,6 @@ void initDI() {
   getIt.registerLazySingleton<SupabaseService>(
     () => SupabaseService(appSecretsProvider: getIt<AppSecretsProvider>()),
   );
-
 
   getIt.registerLazySingleton<AuthenticationRepository>(
     () => AuthenticationRepositoryImpl(
@@ -54,15 +54,16 @@ void initDI() {
   );
 
   getIt.registerLazySingleton<AccountRepository>(
-    () => AccountRepositoryImpl(supabaseService: getIt<SupabaseService>()
-    )
+    () => AccountRepositoryImpl(supabaseService: getIt<SupabaseService>()),
   );
 
   getIt.registerLazySingleton<TransactionRepository>(
     () => TransactionRepositoryStub(getIt<SupabaseService>()),
   );
 
-  getIt.registerLazySingleton<AccountSetupCubit>(() => AccountSetupCubit(getIt<AccountRepository>()));
+  getIt.registerLazySingleton<AccountSetupCubit>(
+    () => AccountSetupCubit(getIt<AccountRepository>()),
+  );
 
   getIt.registerFactory<AddIncomeCubit>(
     () => AddIncomeCubit(repository: getIt<TransactionRepository>()),
@@ -73,25 +74,17 @@ void initDI() {
         TransactionCubit(transactionRepository: getIt<TransactionRepository>()),
   );
 
-  // Statistics
-  // TODO: Remove this when done testing UI
   getIt.registerLazySingleton<StatisticsRepository>(
-    () => FakeStatisticsRepository(),
+    () => StatisticsRepositoryImpl(supabaseService: getIt<SupabaseService>()),
   );
 
-  // getIt.registerLazySingleton<StatisticsRepository>(
-  //       () => StatisticsRepositoryImpl(
-  //     supabaseService: getIt<SupabaseService>(),
-  //   ),
-  // );
-
   getIt.registerFactory<StatisticsCubit>(
-        () => StatisticsCubit(
-      repository: getIt<StatisticsRepository>(),
-    ),
+    () => StatisticsCubit(repository: getIt<StatisticsRepository>()),
   );
 
   getIt.registerFactory<TransactionDetailsCubit>(
-      () => TransactionDetailsCubit(transactionRepository: getIt<TransactionRepository>())
+    () => TransactionDetailsCubit(
+      transactionRepository: getIt<TransactionRepository>(),
+    ),
   );
 }

--- a/lib/data/repository/fake_statistics_repository.dart
+++ b/lib/data/repository/fake_statistics_repository.dart
@@ -2,17 +2,40 @@ import '../../domain/entity/monthly_overview.dart';
 import '../../domain/repository/statistics_repository.dart';
 
 class FakeStatisticsRepository implements StatisticsRepository {
+  final bool shouldFail;
+  final bool shouldReturnEmpty;
+
+  FakeStatisticsRepository({
+    this.shouldFail = false,
+    this.shouldReturnEmpty = false,
+  });
+
   @override
   Future<MonthlyOverview?> getMonthlyOverview({required DateTime month}) async {
     // Simulate network delay
     await Future.delayed(const Duration(seconds: 1));
 
+    if (shouldFail) {
+      throw Exception('Simulated network error');
+    }
+
+    if (shouldReturnEmpty) {
+      return const MonthlyOverview(
+        income: 0,
+        expenses: 0,
+        currency: 'IQD',
+        maxValue: 100000,
+        scaleLabels: ['0', '12.5K', '25K', '37.5K', '50K', '62.5K', '75K', '87.5K', '100K'],
+      );
+    }
+
+    // Simulate successful response matching your UI design
     return const MonthlyOverview(
-      income: 5000.0,
-      expenses: 3500.0,
-      currency: "AED",
-      maxValue: 6000.0,
-      scaleLabels: ["0", "1k", "2k", "3k", "4k", "5k", "6k"],
+      income: 1500000,
+      expenses: 850000,
+      currency: 'IQD',
+      maxValue: 2000000,
+      scaleLabels: ['0', '250K', '500K', '750K', '1M', '1.25M', '1.5M', '1.75M', '2M'],
     );
   }
 }

--- a/lib/data/repository/statistics_repository_impl.dart
+++ b/lib/data/repository/statistics_repository_impl.dart
@@ -1,4 +1,3 @@
-
 import '../../data/service/supabase_service.dart';
 import '../../domain/entity/monthly_overview.dart';
 import '../../domain/repository/statistics_repository.dart';
@@ -11,85 +10,68 @@ class StatisticsRepositoryImpl implements StatisticsRepository {
 
   @override
   Future<MonthlyOverview?> getMonthlyOverview({required DateTime month}) async {
-    final client = await _supabaseService.getClient();
-   // final userId = client.auth.currentUser?.id;
+    try {
+      final client = await _supabaseService.getClient();
+      final userId = client.auth.currentUser?.id;
 
-    final userId = "cdc4f388-4c4a-4ab4-84b1-5076fbe759c9";
-    if (userId == null) {
-      return null;
-    }
-
-
-    // Get first and last day of the month
-    final startOfMonth = DateTime(month.year, month.month, 1);
-    final endOfMonth = DateTime(month.year, month.month + 1, 0, 23, 59, 59);
-
-    // Query transactions for the month
-    final response = await client
-        .from('transactions')
-        .select('''
-          amount,
-          transaction_type,
-          currency_id,
-          currencies!inner(abbreviation, abbreviation_ar)
-        ''')
-        .eq('user_id', userId)
-        .limit(100);
-
-    /* .gte('created_at', startOfMonth.toIso8601String())
-        .lte('created_at', endOfMonth.toIso8601String());*/
-
-    final transactions = response as List<dynamic>;
-
-    print('Total transactions found: ${transactions.length}');
-
-    if (transactions.isEmpty) {
-      return null;
-    }
-
-    // Calculate income and expenses
-    // Assuming transaction_type: 1 = income, 2 = expense (adjust based on your schema)
-    double totalIncome = 0;
-    double totalExpenses = 0;
-    String currency = 'IQD';
-
-    for (final transaction in transactions) {
-      final amount = (transaction['amount'] as num).toDouble();
-      final type = transaction['transaction_type'] as int;
-
-      // Get currency from first transaction
-      if (transaction['currencies'] != null) {
-        currency = transaction['currencies']['abbreviation'] ?? 'IQD';
+      if (userId == null) {
+        return null;
       }
 
-      if (type == 1) {
-        // Income
-        totalIncome += amount;
-      } else {
-        // Expense
-        totalExpenses += amount;
-      }
-    }
+      // Call RPC function
+      final response = await client.rpc(
+        'get_monthly_overview',
+        params: {
+          'in_year': month.year,
+          'in_month': month.month,
+        },
+      );
 
-    // Calculate max value and scale labels dynamically
-    final maxAmount = totalIncome > totalExpenses ? totalIncome : totalExpenses;
+      if (response == null) {
+        return _createEmptyOverview();
+      }
+
+      return _mapResponseToOverview(response as Map<String, dynamic>);
+    } catch (e) {
+      print('Error fetching monthly overview: $e');
+      rethrow;
+    }
+  }
+
+  MonthlyOverview _mapResponseToOverview(Map<String, dynamic> json) {
+    final income = (json['income'] as num).toDouble();
+    final expenses = (json['expenses'] as num).toDouble();
+    final currency = json['currency'] as String? ?? 'IQD';
+
+    // Calculate max value and scale labels
+    final maxAmount = income > expenses ? income : expenses;
     final maxValue = _calculateMaxValue(maxAmount);
     final scaleLabels = _generateScaleLabels(maxValue);
 
     return MonthlyOverview(
-      income: totalIncome,
-      expenses: totalExpenses,
+      income: income,
+      expenses: expenses,
       currency: currency,
       maxValue: maxValue,
       scaleLabels: scaleLabels,
     );
   }
 
+  MonthlyOverview _createEmptyOverview({String currency = 'IQD'}) {
+    final maxValue = _calculateMaxValue(0);
+    return MonthlyOverview(
+      income: 0,
+      expenses: 0,
+      currency: currency,
+      maxValue: maxValue,
+      scaleLabels: _generateScaleLabels(maxValue),
+    );
+  }
+
   double _calculateMaxValue(double maxAmount) {
     if (maxAmount <= 0) return 100000;
 
-    // Round up to nearest significant value
-    final magnitude = maxAmount.toString().length - 1;
+    final magnitude = maxAmount.toString().split('.')[0].length - 1;
     final base = _pow(10, magnitude).toDouble();
     return ((maxAmount / base).ceil() * base).toDouble();
   }

--- a/lib/money_app.dart
+++ b/lib/money_app.dart
@@ -8,7 +8,7 @@ import 'core/l10n/app_localizations.dart';
 
 final _router = GoRouter(
     routes: $appRoutes,
-    initialLocation: '/statistics'
+    initialLocation: '/login'
 );
 
 

--- a/lib/presentation/statistics/cubit/statistics_cubit.dart
+++ b/lib/presentation/statistics/cubit/statistics_cubit.dart
@@ -10,7 +10,7 @@ class StatisticsCubit extends Cubit<StatisticsState> {
       super(const StatisticsIdle());
 
   Future<void> loadStatistics({DateTime? month}) async {
-    final selectedMonth = month ?? DateTime.now();
+    final selectedMonth = month ?? DateTime(2026, 2, 1);
 
     emit(const StatisticsLoading());
 


### PR DESCRIPTION
Refactors the statistics repository to use a Supabase RPC function for fetching monthly overview data instead of direct table queries. This simplifies data retrieval and allows for more complex server-side aggregation.

Also updates `FakeStatisticsRepository` to support error and empty states for testing. Changes initial navigation to `/login`.